### PR TITLE
JBIDE-24788 add skipDeployToJBossOrg=false...

### DIFF
--- a/jboss-fuse-sap-tool-suite/site/pom.xml
+++ b/jboss-fuse-sap-tool-suite/site/pom.xml
@@ -13,4 +13,8 @@
 	<packaging>eclipse-repository</packaging>
 	<name>JBoss Tools Fuse Extras :: SAP Tooling :: Update Site</name>
 
+	<properties>
+		<skipDeployToJBossOrg>false</skipDeployToJBossOrg>
+	</properties>
+
 </project>


### PR DESCRIPTION
JBIDE-24788 add skipDeployToJBossOrg=false so that the update site can be deployed (and the rest of the build will NOT re-deploy everything)

Signed-off-by: nickboldt <nboldt@redhat.com>