### PR TITLE
FUSETOOLS-3076 - explicitly set dependency on javax.xml

### DIFF
--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/META-INF/MANIFEST.MF
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.sap.ui;singleton:=true
 Bundle-Version: 11.1.0.qualifier
 Bundle-Activator: org.fusesource.ide.sap.ui.Activator
-Require-Bundle: org.eclipse.ui,
+Require-Bundle: javax.xml.bind;bundle-version="2.2.0",
+ org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.emf.edit.ui,
  org.eclipse.core.databinding,

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/META-INF/MANIFEST.MF
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.fusesource.ide.sap.ui;singleton:=true
 Bundle-Version: 11.1.0.qualifier
 Bundle-Activator: org.fusesource.ide.sap.ui.Activator
 Require-Bundle: javax.xml.bind;bundle-version="2.2.0",
+ org.jboss.tools.locus.jaxb-impl;bundle-version="2.2.7",
  org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.emf.edit.ui,


### PR DESCRIPTION
it has been removed from core Java SE in Java 9 and completely removed
in Java 11

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Function

- [ ] Does the project still build fine locally?
- [ ] Does your modification work?
- [ ] Is the non-happy path working, too?
- [ ] Are other parts that use the same component still working fine?

## Code Style

- [ ] Are method-/class-/variable-names meaningful?
- [ ] Are methods concise, not too long?
- [ ] Are catch blocks catching precise Exceptions only (no catch all)?
- [ ] Have you used the correct file header copyright comment?
- [ ] Have you set the correct year in the headers of new files?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
