### PR TITLE
FUSETOOLS-3449 - upgrade minimal environment from Java 1.7 to 1.8

### DIFF
--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/.classpath
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/META-INF/MANIFEST.MF
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Require-Bundle: org.eclipse.ui,
  org.fusesource.ide.foundation.ui;bundle-version="10.1.0",
  org.eclipse.emf.transaction,
  org.jboss.tools.common.jaxb;bundle-version="3.10.2";resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ClassPath: .

--- a/jboss-fuse-sap-tool-suite/targetplatform/JBTIS Luna Linux.launch
+++ b/jboss-fuse-sap-tool-suite/targetplatform/JBTIS Luna Linux.launch
@@ -14,7 +14,7 @@
 <booleanAttribute key="includeOptional" value="true"/>
 <stringAttribute key="location" value="./ws_fusetooling_dev"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} &#10;-ws ${target.ws} &#10;-arch ${target.arch} &#10;-nl ${target.nl} &#10;-consoleLog &#10;-console&#10;-Djboss.discovery.directory.url=file:/home/lhein/jbtis.xml"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=1.7&#10;-XX:MaxPermSize=256m &#10;-Xms256m &#10;-Xmx1024m"/>

--- a/jboss-fuse-sap-tool-suite/targetplatform/JBTIS Luna Windows.launch
+++ b/jboss-fuse-sap-tool-suite/targetplatform/JBTIS Luna Windows.launch
@@ -14,7 +14,7 @@
 <booleanAttribute key="includeOptional" value="true"/>
 <stringAttribute key="location" value="./ws_fusetooling_dev"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} &#13;&#10;-ws ${target.ws} &#13;&#10;-arch ${target.arch} &#13;&#10;-nl ${target.nl} &#13;&#10;-consoleLog &#13;&#10;-console"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=1.7&#13;&#10;-XX:MaxPermSize=256m &#13;&#10;-Xms256m &#13;&#10;-Xmx1024m"/>


### PR DESCRIPTION
it was already implicitly the case but wasn't declared correctly in
Manifest

