### PR TITLE
FUSETOOLS-3442 - Migrate from tycho-source-feature-plugin to

### DIFF
--- a/jboss-fuse-sap-tool-suite/features/pom.xml
+++ b/jboss-fuse-sap-tool-suite/features/pom.xml
@@ -17,12 +17,21 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-p2-metadata</id>
+						<phase>package</phase>
+						<goals>
+							<goal>p2-metadata</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
tycho-source-plugin

as recommended after migrated to Tycho 2.2:
[WARNING] Mojo tycho-source-feature-plugin:source-feature is replaced by
the tycho-source-plugin:feature-source which offers equivalent and even
enhanced functionality

