### PR TITLE
FUSETOOLS-3495 - Avoid StackOverflow

### DIFF
--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/CopyHandler.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/CopyHandler.java
@@ -43,7 +43,6 @@ public class CopyHandler extends AbstractHandler implements IHandler {
 
 	@Override
 	public void setEnabled(Object evaluationContext) {
-		setBaseEnabled(false);
 		Object obj = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 		if (obj instanceof IStructuredSelection) {
 			IStructuredSelection selection = (IStructuredSelection) obj;
@@ -62,11 +61,13 @@ public class CopyHandler extends AbstractHandler implements IHandler {
 								command = new CopyDestinationDataStoreEntryToClipboard(editingDomain, destinationDataStore, destinationDataStoreEntry);
 							}
 							setBaseEnabled(true);
+							return;
 						}
 					}
 				}
 			}
 		}
+		setBaseEnabled(false);
 	}
 
 	protected boolean canCopy(IStructuredSelection selection) {

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/CutHandler.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/CutHandler.java
@@ -43,7 +43,6 @@ public class CutHandler extends AbstractHandler {
 
 	@Override
 	public void setEnabled(Object evaluationContext) {
-		setBaseEnabled(false);
 		Object obj = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 		if (obj instanceof IStructuredSelection) {
 			IStructuredSelection selection = (IStructuredSelection) obj;
@@ -59,11 +58,13 @@ public class CutHandler extends AbstractHandler {
 							command.append(cutToClipboardCommand);
 							command.append(createRemoveValueCommand(obj));
 							setBaseEnabled(true);
+							return;
 						}
 					}
 				}
 			}
 		}
+		setBaseEnabled(false);
 	}
 	
 	protected Command createRemoveValueCommand(Object value) {

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/DeleteHandler.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/DeleteHandler.java
@@ -48,7 +48,6 @@ public class DeleteHandler extends AbstractHandler implements IHandler {
 	public void setEnabled(Object evaluationContext) {
 		Command deleteEntryCommand = null;
 		Command removeValueCommand = null;
-		setBaseEnabled(false);
 		Object obj = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 		if (obj instanceof IStructuredSelection) {
 			IStructuredSelection selection = (IStructuredSelection) obj;
@@ -71,11 +70,13 @@ public class DeleteHandler extends AbstractHandler implements IHandler {
 							command.append(deleteEntryCommand);
 							command.append(removeValueCommand);
 							setBaseEnabled(true);
+							return;
 						}
 					}
 				}
 			}
 		}
+		setBaseEnabled(false);
 	}
 
 	protected boolean canDelete(IStructuredSelection selection) {

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/NewDestinationHandler.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/NewDestinationHandler.java
@@ -79,7 +79,6 @@ public class NewDestinationHandler extends AbstractHandler {
 	public void setEnabled(Object evaluationContext) {
 		Command createDestinationDataStoreEntryCommand = null;
 		Command createDestinationDataCommand = null;
-		setBaseEnabled(false);
 		Object obj = getActiveSelection(evaluationContext);
 		if (obj instanceof IStructuredSelection) {
 			obj = ((IStructuredSelection)obj).getFirstElement();
@@ -107,11 +106,13 @@ public class NewDestinationHandler extends AbstractHandler {
 						command.append(SetCommand.create(editingDomain, destinationDataStoreEntry, RfcPackage.Literals.DESTINATION_DATA_STORE_ENTRY__VALUE, destinationData));
 						command.append(createDestinationDataStoreEntryCommand);
 						setBaseEnabled(true);
+						return;
 					}
 				}
 				
 			}
 		}		
+		setBaseEnabled(false);
 	}
 
 	/**

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/NewServerHandler.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/NewServerHandler.java
@@ -67,7 +67,6 @@ public class NewServerHandler extends AbstractHandler {
 	public void setEnabled(Object evaluationContext) {
 		Command createServerDataStoreEntryCommand = null;
 		Command createServerDataCommand = null;
-		setBaseEnabled(false);
 		Object obj = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 		if (obj instanceof IStructuredSelection) {
 			obj = ((IStructuredSelection)obj).getFirstElement();
@@ -95,11 +94,13 @@ public class NewServerHandler extends AbstractHandler {
 						command.append(SetCommand.create(editingDomain, serverDataStoreEntry, RfcPackage.Literals.SERVER_DATA_STORE_ENTRY__VALUE, serverData));
 						command.append(createServerDataStoreEntryCommand);
 						setBaseEnabled(true);
+						return;
 					}
 				}
 				
 			}
 		}		
+		setBaseEnabled(false);
 	}
 	
 }

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/PasteHandler.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/PasteHandler.java
@@ -75,7 +75,6 @@ public class PasteHandler extends AbstractHandler {
 
 	@Override
 	public void setEnabled(Object evaluationContext) {
-		setBaseEnabled(false);
 		Object obj = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 		if (obj instanceof IStructuredSelection) {
 			IStructuredSelection selection = (IStructuredSelection) obj;
@@ -91,11 +90,13 @@ public class PasteHandler extends AbstractHandler {
 							command.append(createAddValueCommand(obj, editingDomain.getClipboard()));
 							command.append(pasteFromClipboardCommand);
 							setBaseEnabled(true);
+							return;
 						}
 					}
 				}
 			}
 		}
+		setBaseEnabled(false);
 	}
 	
 	protected Command createAddValueCommand(Object owner, Collection<Object> values) {

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/RedoHandler.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/RedoHandler.java
@@ -37,15 +37,16 @@ public class RedoHandler extends AbstractHandler implements IHandler, IElementUp
 
 	@Override
 	public void setEnabled(Object evaluationContext) {
-		setBaseEnabled(false);
 		Object obj = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_PART_NAME);
 		if (obj instanceof SapConnectionsView) {
 			SapConnectionsView view = (SapConnectionsView) obj;
 			editingDomain = view.getEditingDomain();
 			if (editingDomain.getCommandStack().canRedo()) {
 				setBaseEnabled(true);
+				return;
 			}
 		}
+		setBaseEnabled(false);
 	}
 
 	@Override

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/TestHandler.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/TestHandler.java
@@ -55,7 +55,6 @@ public class TestHandler extends AbstractHandler implements IHandler {
 
 	@Override
 	public void setEnabled(Object evaluationContext) {
-		setBaseEnabled(false);
 		Object obj = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 		if (obj instanceof IStructuredSelection) {
 			IStructuredSelection selection = (IStructuredSelection) obj;
@@ -65,13 +64,16 @@ public class TestHandler extends AbstractHandler implements IHandler {
 					name = ((DestinationDataStoreEntryImpl) obj).getKey();
 					isDestination = true;
 					setBaseEnabled(true);
+					return;
 				} else if (obj instanceof ServerDataStoreEntryImpl) {
 					name = ((ServerDataStoreEntryImpl) obj).getKey();
 					isDestination = false;
 					setBaseEnabled(true);
+					return;
 				}
 			}
 		}
+		setBaseEnabled(false);
 	}
 
 }

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/UndoHandler.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/command/UndoHandler.java
@@ -37,15 +37,16 @@ public class UndoHandler extends AbstractHandler implements IHandler, IElementUp
 
 	@Override
 	public void setEnabled(Object evaluationContext) {
-		setBaseEnabled(false);
 		Object obj = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_PART_NAME);
 		if (obj instanceof SapConnectionsView) {
 			SapConnectionsView view = (SapConnectionsView) obj;
 			editingDomain = view.getEditingDomain();
 			if (editingDomain.getCommandStack().canUndo()) {
 				setBaseEnabled(true);
+				return;
 			}
 		}
+		setBaseEnabled(false);
 	}
 
 	@Override


### PR DESCRIPTION
avoid calling setBaseEnabled several times with different values in the
same setEnabled method call

![rightClickWorkingToTestConnection](https://user-images.githubusercontent.com/1105127/125413893-4b705b5e-a060-471b-9cdd-c5304dfc05c2.gif)


use case is tested from 2 UI tests (currently deactivbated due to https://issues.redhat.com/browse/FUSETOOLS-3322 ):
- https://github.com/jbosstools/jbosstools-fuse-extras/blob/d1c0db6aee22405e5e6a11c6e5cbfb55cf55c051/jboss-fuse-sap-tool-suite/uitests/tests/org.jboss.tools.fuse.sap.ui.bot.tests/src/org/jboss/tools/fuse/sap/ui/bot/tests/SAPConfigurationTest.java#L146
- https://github.com/jbosstools/jbosstools-fuse-extras/blob/d1c0db6aee22405e5e6a11c6e5cbfb55cf55c051/jboss-fuse-sap-tool-suite/uitests/tests/org.jboss.tools.fuse.sap.ui.bot.tests/src/org/jboss/tools/fuse/sap/ui/bot/tests/SAPConnectionTest.java#L77