### PR TITLE
FUSETOOLS-3540 - update related to migration of Master to Main branch

### DIFF
--- a/.github/ReadMe.md
+++ b/.github/ReadMe.md
@@ -43,9 +43,9 @@ Follow the [@FuseTooling](https://twitter.com/fusetooling) account to grab some 
 
 ## Building
 
-If you want to know how to build the project and setup an Eclipse workspace for development please read the [build guide](https://github.com/jbosstools/jbosstools-fuse/blob/master/Build.md "Build Guide").
+If you want to know how to build the project and setup an Eclipse workspace for development please read the [build guide](https://github.com/jbosstools/jbosstools-fuse/blob/main/Build.md "Build Guide").
 
 ## Contributing
 
-If you want to contribute to Fuse Tooling make sure you read the [contribution guide](https://github.com/jbosstools/jbosstools-fuse/blob/master/Contributing.md "Contribution Guide").
+If you want to contribute to Fuse Tooling make sure you read the [contribution guide](https://github.com/jbosstools/jbosstools-fuse/blob/main/Contributing.md "Contribution Guide").
 please the specific [Readme](jboss-fuse-sap-tool-suite/targetplatform/ReadMe.md) for Target Platform too.


### PR DESCRIPTION
it remains 2 places with mention of master but it is things that has nto been renamed externally, like http://download.jboss.org/jbosstools/photon/snapshots/builds/jbosstools-fuse_master