### PR TITLE
FUSETOOLS-3617 - Support SAP in palette for Fuse 7+

### DIFF
--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/globalconf/provider/SAPServerContribution.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/globalconf/provider/SAPServerContribution.java
@@ -10,12 +10,12 @@
  ******************************************************************************/ 
 package org.fusesource.ide.sap.ui.editor.globalconf.provider;
 
-import static org.fusesource.ide.sap.ui.Activator.CAMEL_SAP_ARTIFACT_ID;
 import static org.fusesource.ide.sap.ui.Activator.CAMEL_SAP_GROUP_ID;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -28,6 +28,8 @@ import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
+import org.fusesource.ide.camel.model.service.core.util.CamelCatalogUtils;
+import org.fusesource.ide.sap.ui.editor.provider.SAPArtifactIdDependenciesManager;
 import org.fusesource.ide.sap.ui.editor.provider.SAPVersionDependenciesManager;
 import org.fusesource.ide.sap.ui.export.SapGlobalConnectionConfigurationWizard;
 import org.w3c.dom.Element;
@@ -79,12 +81,24 @@ public class SAPServerContribution implements ICustomGlobalConfigElementContribu
 	 */
 	@Override
 	public List<Dependency> getElementDependencies() {
+		String runtimeProvider = CamelCatalogUtils.getRuntimeprovider(CamelUtils.project(), new NullProgressMonitor());
+		return getElementDependencies(runtimeProvider);
+	}
+
+	public List<Dependency> getElementDependencies(String runtimeProvider) {
 		List<Dependency> deps = new ArrayList<>();
 		
 		Dependency dep = new Dependency();
         dep.setGroupId(CAMEL_SAP_GROUP_ID);
-        dep.setArtifactId(CAMEL_SAP_ARTIFACT_ID);
-        dep.setVersion(new SAPVersionDependenciesManager().computeSapVersion(CamelUtils.getCurrentProjectCamelVersion()));
+        dep.setArtifactId(new SAPArtifactIdDependenciesManager().getArtifactId(runtimeProvider));
+        
+        String currentProjectCamelVersion = CamelUtils.getCurrentProjectCamelVersion();
+		if (currentProjectCamelVersion.startsWith("2.15")
+				|| currentProjectCamelVersion.startsWith("2.17")) {
+			dep.setVersion(new SAPVersionDependenciesManager().computeSapVersion(currentProjectCamelVersion));
+		} else {
+			// we consider as a shortcut that it is a 7.x version and that there is a bom managing the version
+		}
         deps.add(dep);
 		
 		return deps;

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/AbstractSAPPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/AbstractSAPPaletteEntry.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.fusesource.ide.sap.ui.editor.provider;
 
-import static org.fusesource.ide.sap.ui.Activator.CAMEL_SAP_ARTIFACT_ID;
 import static org.fusesource.ide.sap.ui.Activator.CAMEL_SAP_GROUP_ID;
 
 import java.util.ArrayList;
@@ -19,29 +18,31 @@ import java.util.List;
 import org.fusesource.ide.camel.editor.provider.ext.ICustomPaletteEntry;
 import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
-import org.fusesource.ide.camel.model.service.core.util.CamelCatalogUtils;
 
 public abstract class AbstractSAPPaletteEntry implements ICustomPaletteEntry{
 
 	@Override
 	public List<Dependency> getRequiredDependencies(String runtimeProvider) {
-		//SAP supports only Karaf deployment
-	    return getRequiredDependencies();
-	}
-	
-	public List<Dependency> getRequiredDependencies() {
-	    List<Dependency> deps = new ArrayList<>();
-	    Dependency dep = new Dependency();
-	    dep.setGroupId(CAMEL_SAP_GROUP_ID);
-	    dep.setArtifactId(CAMEL_SAP_ARTIFACT_ID);
-	    dep.setVersion(new SAPVersionDependenciesManager().computeSapVersion(CamelUtils.getCurrentProjectCamelVersion()));
-	    deps.add(dep);
-	    return deps;
+		List<Dependency> deps = new ArrayList<>();
+		Dependency dep = new Dependency();
+		dep.setGroupId(CAMEL_SAP_GROUP_ID);
+		dep.setArtifactId(new SAPArtifactIdDependenciesManager().getArtifactId(runtimeProvider));
+		String currentProjectCamelVersion = CamelUtils.getCurrentProjectCamelVersion();
+		if (currentProjectCamelVersion.startsWith("2.15")
+				|| currentProjectCamelVersion.startsWith("2.17")) {
+			dep.setVersion(new SAPVersionDependenciesManager().computeSapVersion(currentProjectCamelVersion));
+		} else {
+			// we consider as a shortcut that it is a 7.x version and that there is a bom managing the version
+		}
+		deps.add(dep);
+		return deps;
 	}
 	
 	@Override
 	public boolean isValid(String runtimeProvider) {
-		return CamelCatalogUtils.RUNTIME_PROVIDER_KARAF.equals(runtimeProvider);
+		// In fact, it is not valid on SpringBoot with Fuse 6.x but it requires too much modifications for this old version,
+		// so showing the SAP palette entry for all versions
+		return true;
 	}
 
 }

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SAPArtifactIdDependenciesManager.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SAPArtifactIdDependenciesManager.java
@@ -1,0 +1,28 @@
+/******************************************************************************* 
+ * Copyright (c) 2022 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.fusesource.ide.sap.ui.editor.provider;
+
+import org.fusesource.ide.camel.model.service.core.util.CamelCatalogUtils;
+import org.fusesource.ide.sap.ui.Activator;
+
+public class SAPArtifactIdDependenciesManager {
+
+	public String getArtifactId(String runtimeProvider) {
+		if(CamelCatalogUtils.RUNTIME_PROVIDER_KARAF.equals(runtimeProvider)
+				|| CamelCatalogUtils.RUNTIME_PROVIDER_WILDFLY.equals(runtimeProvider)) {
+			return Activator.CAMEL_SAP_ARTIFACT_ID;
+		} else if (CamelCatalogUtils.RUNTIME_PROVIDER_SPRINGBOOT.equals(runtimeProvider)) {
+			return Activator.CAMEL_SAP_ARTIFACT_ID +"-starter";
+		} else {
+			return Activator.CAMEL_SAP_ARTIFACT_ID;
+		}
+	}
+}

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapIDocDestinationPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapIDocDestinationPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 
 public class SapIDocDestinationPaletteEntry extends AbstractSAPPaletteEntry {
@@ -29,7 +30,7 @@ public class SapIDocDestinationPaletteEntry extends AbstractSAPPaletteEntry {
 	 */
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapIDocListDestinationPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapIDocListDestinationPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 public class SapIDocListDestinationPaletteEntry extends AbstractSAPPaletteEntry {
 	
@@ -28,7 +29,7 @@ public class SapIDocListDestinationPaletteEntry extends AbstractSAPPaletteEntry 
 	 */
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapIDocListServerPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapIDocListServerPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 public class SapIDocListServerPaletteEntry extends AbstractSAPPaletteEntry {
 	
@@ -24,7 +25,7 @@ public class SapIDocListServerPaletteEntry extends AbstractSAPPaletteEntry {
 
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapQueuedIDocDestinationPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapQueuedIDocDestinationPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 public class SapQueuedIDocDestinationPaletteEntry extends AbstractSAPPaletteEntry {
 	
@@ -24,7 +25,7 @@ public class SapQueuedIDocDestinationPaletteEntry extends AbstractSAPPaletteEntr
 
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapQueuedIDocListDestinationPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapQueuedIDocListDestinationPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 public class SapQueuedIDocListDestinationPaletteEntry extends AbstractSAPPaletteEntry {
 	
@@ -24,7 +25,7 @@ public class SapQueuedIDocListDestinationPaletteEntry extends AbstractSAPPalette
 
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapQueuedRfcDestinationPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapQueuedRfcDestinationPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 public class SapQueuedRfcDestinationPaletteEntry extends AbstractSAPPaletteEntry {
 	
@@ -24,7 +25,7 @@ public class SapQueuedRfcDestinationPaletteEntry extends AbstractSAPPaletteEntry
 
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapSynchronousRfcDestinationPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapSynchronousRfcDestinationPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 public class SapSynchronousRfcDestinationPaletteEntry extends AbstractSAPPaletteEntry {
 	
@@ -24,7 +25,7 @@ public class SapSynchronousRfcDestinationPaletteEntry extends AbstractSAPPalette
 	
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapSynchronousRfcServerPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapSynchronousRfcServerPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 public class SapSynchronousRfcServerPaletteEntry extends AbstractSAPPaletteEntry {
 	
@@ -24,7 +25,7 @@ public class SapSynchronousRfcServerPaletteEntry extends AbstractSAPPaletteEntry
 
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapTransactionalRfcDestinationPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapTransactionalRfcDestinationPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 public class SapTransactionalRfcDestinationPaletteEntry extends AbstractSAPPaletteEntry {
 	
@@ -24,7 +25,7 @@ public class SapTransactionalRfcDestinationPaletteEntry extends AbstractSAPPalet
 
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapTransactionalRfcServerPaletteEntry.java
+++ b/jboss-fuse-sap-tool-suite/plugins/org.fusesource.ide.sap.ui/src/org/fusesource/ide/sap/ui/editor/provider/SapTransactionalRfcServerPaletteEntry.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.sap.ui.editor.provider;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 
 public class SapTransactionalRfcServerPaletteEntry extends AbstractSAPPaletteEntry {
 	
@@ -24,7 +25,7 @@ public class SapTransactionalRfcServerPaletteEntry extends AbstractSAPPaletteEnt
 
 	@Override
 	public ICreateFeature newCreateFeature(IFeatureProvider fp) {
-		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies()); 
+		return new CreateEndpointFigureFeature(fp, COMPONENT_NAME, COMPONENT_DESCRIPTION, COMPONENT_URL, getRequiredDependencies(CamelUtils.getRuntimeProvider(fp))); 
 	}
 
 	/* (non-Javadoc)

--- a/jboss-fuse-sap-tool-suite/tests/org.fusesource.ide.sap.ui.tests.integration/src/main/java/org/fusesource/ide/sap/ui/tests/integration/editor/globalconf/provider/SAPServerContributionIT.java
+++ b/jboss-fuse-sap-tool-suite/tests/org.fusesource.ide.sap.ui.tests.integration/src/main/java/org/fusesource/ide/sap/ui/tests/integration/editor/globalconf/provider/SAPServerContributionIT.java
@@ -13,19 +13,28 @@ package org.fusesource.ide.sap.ui.tests.integration.editor.globalconf.provider;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
+import org.fusesource.ide.camel.model.service.core.util.CamelCatalogUtils;
 import org.fusesource.ide.sap.ui.editor.globalconf.provider.SAPServerContribution;
-import org.fusesource.ide.sap.ui.editor.provider.SAPVersionDependenciesManager;
 import org.junit.Test;
 
 public class SAPServerContributionIT {
 	
 	@Test
-	public void testSAPDepenencyCorrect() throws Exception {
-		Dependency dependency = new SAPServerContribution().getElementDependencies().get(0);
+	public void testSAPDependencyCorrectForKaraf() throws Exception {
+		Dependency dependency = new SAPServerContribution().getElementDependencies(CamelCatalogUtils.RUNTIME_PROVIDER_KARAF).get(0);
 		
 		assertThat(dependency.getGroupId()).isEqualTo("org.fusesource");
 		assertThat(dependency.getArtifactId()).isEqualTo("camel-sap");
-		assertThat(dependency.getVersion()).isEqualTo(SAPVersionDependenciesManager.LAST_SAP_VERSION);
+		assertThat(dependency.getVersion()).isNull();
+	}
+	
+	@Test
+	public void testSAPDependencyCorrectForSpringBoot() throws Exception {
+		Dependency dependency = new SAPServerContribution().getElementDependencies(CamelCatalogUtils.RUNTIME_PROVIDER_SPRINGBOOT).get(0);
+		
+		assertThat(dependency.getGroupId()).isEqualTo("org.fusesource");
+		assertThat(dependency.getArtifactId()).isEqualTo("camel-sap-starter");
+		assertThat(dependency.getVersion()).isNull();
 	}
 	
 }


### PR DESCRIPTION
a limitation is that despite it is not supported for non Karaf in
previous version than Fuse 7, the palette entries are displayed. it
avoid to refactor too much of code for a very old version which is out
of support timeframe

The icons in palette are now also provided for SpringBoot and wildfly/EAP.
![Screenshot from 2022-03-14 10-32-30](https://user-images.githubusercontent.com/1105127/158144586-5db0bd25-55c4-4ab6-be54-596c2e7e0b76.png)

Note that it will create project with error if user has not configured a way to access the commercial sap artifacts: com.sap.conn.idoc:sapidoc3 and com.sap.conn.jco:sapjco3 (I do not know where to get them)

